### PR TITLE
[FEATURE] Support comma-separated lists in page tree filter

### DIFF
--- a/typo3/sysext/backend/Classes/Tree/Repository/PageTreeRepository.php
+++ b/typo3/sysext/backend/Classes/Tree/Repository/PageTreeRepository.php
@@ -27,6 +27,7 @@ use TYPO3\CMS\Core\Database\Query\Restriction\WorkspaceRestriction;
 use TYPO3\CMS\Core\DataHandling\PlainDataResolver;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Core\Versioning\VersionState;
 
 /**
@@ -532,22 +533,33 @@ class PageTreeRepository
                 QueryHelper::stripLogicalOperatorPrefix($additionalWhereClause)
             );
 
-        $searchParts = $expressionBuilder->orX();
-        if (is_numeric($searchFilter) && $searchFilter > 0) {
+        $searchParts = $expressionBuilder->or();
+
+        // Extract true integers from search string
+        $searchUids = [];
+        $searchPhrases = GeneralUtility::trimExplode(',', $searchFilter, true);
+        foreach ($searchPhrases as $searchPhrase) {
+            if (MathUtility::canBeInterpretedAsInteger($searchPhrase) && $searchPhrase > 0) {
+                $searchUids[] = (int)$searchPhrase;
+            }
+        }
+        $searchUids = array_unique($searchUids);
+
+        if (!empty($searchUids)) {
             // Ensure that the LIVE id is also found
             if ($this->currentWorkspace > 0) {
                 $uidFilter = $expressionBuilder->or(
                     $expressionBuilder->and(
-                        $expressionBuilder->eq('uid', $queryBuilder->createNamedParameter($searchFilter, Connection::PARAM_INT)),
+                        $expressionBuilder->in('uid', $queryBuilder->createNamedParameter($searchUids, Connection::PARAM_INT_ARRAY)),
                         $expressionBuilder->eq('t3ver_wsid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
                     ),
                     $expressionBuilder->and(
-                        $expressionBuilder->eq('t3ver_oid', $queryBuilder->createNamedParameter($searchFilter, Connection::PARAM_INT)),
+                        $expressionBuilder->in('t3ver_oid', $queryBuilder->createNamedParameter($searchUids, Connection::PARAM_INT_ARRAY)),
                         $expressionBuilder->eq('t3ver_wsid', $queryBuilder->createNamedParameter($this->currentWorkspace, Connection::PARAM_INT)),
                     )
                 );
             } else {
-                $uidFilter = $expressionBuilder->eq('uid', $queryBuilder->createNamedParameter($searchFilter, Connection::PARAM_INT));
+                $uidFilter = $expressionBuilder->in('uid', $queryBuilder->createNamedParameter($searchUids, Connection::PARAM_INT_ARRAY));
             }
             $searchParts = $searchParts->with($uidFilter);
         }

--- a/typo3/sysext/backend/Tests/Functional/Tree/Repository/Fixtures/PageTree.csv
+++ b/typo3/sysext/backend/Tests/Functional/Tree/Repository/Fixtures/PageTree.csv
@@ -4,8 +4,10 @@
 ,2,1,32,"Main Area",0,0,0
 ,20,2,64,"Main Area Sub 1",0,0,0
 ,21,2,128,"Main Area Sub 2",0,0,0
+,22,2,256,"Main Area Sub 3 (called 30,32)",0,0,0
 ,30,21,64,"Sub Area 1",0,0,0
 ,31,21,128,"Sub Area 2",0,0,0
+,32,21,256,"Sub Area 3",0,0,0
 ,3,0,512,"Home 2",0,0,0
 ,1003,2,512,"Main Area Sub 1 Modified",1,20,0
 ,1004,2,512,"Main Area Sub 1 Modified in WS2",2,20,0

--- a/typo3/sysext/backend/Tests/Functional/Tree/Repository/PageTreeRepositoryTest.php
+++ b/typo3/sysext/backend/Tests/Functional/Tree/Repository/PageTreeRepositoryTest.php
@@ -70,7 +70,17 @@ class PageTreeRepositoryTest extends FunctionalTestCase
                                         'title' => 'Sub Area 2',
                                         '_children' => [],
                                     ],
+                                    [
+                                        'uid' => 32,
+                                        'title' => 'Sub Area 3',
+                                        '_children' => [],
+                                    ],
                                 ],
+                            ],
+                            [
+                                'uid' => 22,
+                                'title' => 'Main Area Sub 3 (called 30,32)',
+                                '_children' => [],
                             ],
                         ],
                     ],
@@ -103,6 +113,11 @@ class PageTreeRepositoryTest extends FunctionalTestCase
                             [
                                 'uid' => 21,
                                 'title' => 'Main Area Sub 2',
+                                '_children' => [],
+                            ],
+                            [
+                                'uid' => 22,
+                                'title' => 'Main Area Sub 3 (called 30,32)',
                                 '_children' => [],
                             ],
                         ],
@@ -148,7 +163,17 @@ class PageTreeRepositoryTest extends FunctionalTestCase
                                         'title' => 'Sub Area 2',
                                         '_children' => [],
                                     ],
+                                    [
+                                        'uid' => 32,
+                                        'title' => 'Sub Area 3',
+                                        '_children' => [],
+                                    ],
                                 ],
+                            ],
+                            [
+                                'uid' => 22,
+                                'title' => 'Main Area Sub 3 (called 30,32)',
+                                '_children' => [],
                             ],
                         ],
                     ],
@@ -198,7 +223,17 @@ class PageTreeRepositoryTest extends FunctionalTestCase
                                         'title' => 'Sub Area 2',
                                         '_children' => [],
                                     ],
+                                    [
+                                        'uid' => 32,
+                                        'title' => 'Sub Area 3',
+                                        '_children' => [],
+                                    ],
                                 ],
+                            ],
+                            [
+                                'uid' => 22,
+                                'title' => 'Main Area Sub 3 (called 30,32)',
+                                '_children' => [],
                             ],
                         ],
                     ],
@@ -214,6 +249,11 @@ class PageTreeRepositoryTest extends FunctionalTestCase
                             [
                                 'uid' => 31,
                                 'title' => 'Sub Area 2',
+                                '_children' => [],
+                            ],
+                            [
+                                'uid' => 32,
+                                'title' => 'Sub Area 3',
                                 '_children' => [],
                             ],
                         ],
@@ -284,6 +324,11 @@ class PageTreeRepositoryTest extends FunctionalTestCase
                                     ],
                                 ],
                             ],
+                            [
+                                'uid' => 22,
+                                'title' => 'Main Area Sub 3 (called 30,32)',
+                                '_children' => [],
+                            ],
                         ],
                     ],
                 ],
@@ -303,6 +348,188 @@ class PageTreeRepositoryTest extends FunctionalTestCase
                         '_children' => [],
                     ],
                 ],
+            ],
+        ];
+        yield 'Two finds by comma separated UIDs' => [
+            '30,31',
+            0,
+            1,
+            [
+                'uid' => 1,
+                'title' => 'Home',
+                '_children' => [
+                    [
+                        'uid' => 2,
+                        'title' => 'Main Area',
+                        '_children' => [
+                            [
+                                'uid' => 21,
+                                'title' => 'Main Area Sub 2',
+                                '_children' => [
+                                    [
+                                        'uid' => 30,
+                                        'title' => 'Sub Area 1',
+                                        '_children' => [],
+                                    ],
+                                    [
+                                        'uid' => 31,
+                                        'title' => 'Sub Area 2',
+                                        '_children' => [],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        yield 'Three finds by comma separated UIDs' => [
+            '30,32',
+            0,
+            1,
+            [
+                'uid' => 1,
+                'title' => 'Home',
+                '_children' => [
+                    [
+                        'uid' => 2,
+                        'title' => 'Main Area',
+                        '_children' => [
+                            [
+                                'uid' => 21,
+                                'title' => 'Main Area Sub 2',
+                                '_children' => [
+                                    [
+                                        'uid' => 30,
+                                        'title' => 'Sub Area 1',
+                                        '_children' => [],
+                                    ],
+                                    [
+                                        'uid' => 32,
+                                        'title' => 'Sub Area 3',
+                                        '_children' => [],
+                                    ],
+                                ],
+                            ],
+                            [
+                                'uid' => 22,
+                                'title' => 'Main Area Sub 3 (called 30,32)',
+                                '_children' => [],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        yield 'Two finds by comma separated UIDs and a string' => [
+            '30,string,31',
+            0,
+            1,
+            [
+                'uid' => 1,
+                'title' => 'Home',
+                '_children' => [
+                    [
+                        'uid' => 2,
+                        'title' => 'Main Area',
+                        '_children' => [
+                            [
+                                'uid' => 21,
+                                'title' => 'Main Area Sub 2',
+                                '_children' => [
+                                    [
+                                        'uid' => 30,
+                                        'title' => 'Sub Area 1',
+                                        '_children' => [],
+                                    ],
+                                    [
+                                        'uid' => 31,
+                                        'title' => 'Sub Area 2',
+                                        '_children' => [],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        yield 'One find by comma separated negative and positive UIDs' => [
+            '-30,31',
+            0,
+            1,
+            [
+                'uid' => 1,
+                'title' => 'Home',
+                '_children' => [
+                    [
+                        'uid' => 2,
+                        'title' => 'Main Area',
+                        '_children' => [
+                            [
+                                'uid' => 21,
+                                'title' => 'Main Area Sub 2',
+                                '_children' => [
+                                    [
+                                        'uid' => 31,
+                                        'title' => 'Sub Area 2',
+                                        '_children' => [],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        yield 'No finds by arbitrary string' => [
+            bin2hex(random_bytes(20)),
+            0,
+            0,
+            [
+                'uid' => 0,
+                'title' => 'New TYPO3 site',
+                '_children' => [],
+            ],
+        ];
+        yield 'No finds by string starting with int' => [
+            '30isAnInteger',
+            0,
+            0,
+            [
+                'uid' => 0,
+                'title' => 'New TYPO3 site',
+                '_children' => [],
+            ],
+        ];
+        yield 'No finds by string ending with int' => [
+            'AnIntegerIs30',
+            0,
+            0,
+            [
+                'uid' => 0,
+                'title' => 'New TYPO3 site',
+                '_children' => [],
+            ],
+        ];
+        yield 'No finds by float' => [
+            '30.0',
+            0,
+            0,
+            [
+                'uid' => 0,
+                'title' => 'New TYPO3 site',
+                '_children' => [],
+            ],
+        ];
+        yield 'No finds by exponential format' => [
+            '2e+1', // that's a 20
+            0,
+            0,
+            [
+                'uid' => 0,
+                'title' => 'New TYPO3 site',
+                '_children' => [],
             ],
         ];
     }

--- a/typo3/sysext/core/Documentation/Changelog/13.1/Feature-103220-EnhancePagetreeFilterBySupportingListsOfPids.rst
+++ b/typo3/sysext/core/Documentation/Changelog/13.1/Feature-103220-EnhancePagetreeFilterBySupportingListsOfPids.rst
@@ -1,0 +1,17 @@
+.. include:: /Includes.rst.txt
+
+.. _feature-103220-1709106910:
+
+===========================================================================
+Feature: #103220 - Enhance page tree filter by supporting lists of page IDs
+===========================================================================
+
+See :issue:`103220`
+
+Description
+===========
+
+The page tree has been enhanced to enable the user to not only search for
+strings and single page IDs, but for comma-separated lists of page IDs as well.
+
+.. index:: Backend, ext:backend


### PR DESCRIPTION
With this patch it's possible to filter the page tree not only by strings and single uids but by comma-separated lists of uids.

v11 backport of https://review.typo3.org/c/Packages/TYPO3.CMS/+/83153